### PR TITLE
Remove extern and replace with use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-stats
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-stats.svg?branch=master)](https://travis-ci.com/peachcloud/peach-stats) ![Generic badge](https://img.shields.io/badge/version-0.1.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-stats.svg?branch=master)](https://travis-ci.com/peachcloud/peach-stats) ![Generic badge](https://img.shields.io/badge/version-0.1.1-<COLOR>.svg)
 
 System statistics microservice module for PeachCloud. Provides a JSON-RPC wrapper around the [probes](https://crates.io/crates/probes) and [systemstat](https://crates.io/crates/systemstat) crates.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate log;
-
 mod error;
 mod stats;
 mod structs;
@@ -11,6 +8,7 @@ use jsonrpc_core::{IoHandler, Value};
 use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
 #[allow(unused_imports)]
 use jsonrpc_test as test;
+use log::info;
 
 use crate::error::BoxError;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-extern crate peach_stats;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-
 use std::process;
+
+use log::error;
 
 fn main() {
     // initialize the logger


### PR DESCRIPTION
Minor changes to remove unidiomatic use of `extern` (no longer required since Rust 2018 edition).